### PR TITLE
[bug-fix] Update service.yaml

### DIFF
--- a/argocd/example-app/service.yaml
+++ b/argocd/example-app/service.yaml
@@ -8,5 +8,5 @@ spec:
     app: argocd-example-app
   ports:
     - port: 3000
-      targetPort: 3000
+      targetPort: 80
       nodePort: 31000 # Optional: Kubernetes will choose a port if this is omitted


### PR DESCRIPTION
Correct the targetPort

```
kubectl exec -it pod/argocd-example-app-697f8c97b4-hnwfq -n argocd-example-app -- netstat -tulpn
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      1/nginx: master pro
tcp        0      0 :::80                   :::*                    LISTEN      1/nginx: master pro
```

Nginx is listening in port 80, not 3000.